### PR TITLE
Fix `fee_stats` request and `OperationFeeStatsResponse` 

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -493,9 +493,9 @@ class OffersRequestBuilder extends RequestBuilder {
 
 class OperationFeeStatsRequestBuilder extends RequestBuilder {
   OperationFeeStatsRequestBuilder(http.Client httpClient, Uri serverURI)
-      : super(httpClient, serverURI, ["operation_fee_stats"]);
+      : super(httpClient, serverURI, ["fee_stats"]);
 
-  ///Requests <code>GET /operation_fee_stats</code>
+  ///Requests <code>GET /fee_stats</code>
   Future<OperationFeeStatsResponse> execute() async {
     TypeToken type = new TypeToken<OperationFeeStatsResponse>();
     ResponseHandler<OperationFeeStatsResponse> responseHandler =

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -714,7 +714,7 @@ class OperationFeeStatsResponse extends Response {
   int lastLedger;
 
   OperationFeeStatsResponse(
-      int min, int mode, int lastLedgerBaseFee, int lastLedger);
+      int this.min, int this.mode, int this.lastLedgerBaseFee, int this.lastLedger);
 
   factory OperationFeeStatsResponse.fromJson(Map<String, dynamic> json) {
     return new OperationFeeStatsResponse(

--- a/lib/src/transaction.dart
+++ b/lib/src/transaction.dart
@@ -244,8 +244,8 @@ class Transaction {
   }
 
   ///Generates TransactionEnvelope XDR object. Transaction need to have at least one signature.
-  XdrTransactionEnvelope toEnvelopeXdr() {
-    if (_mSignatures.length == 0) {
+  XdrTransactionEnvelope toEnvelopeXdr({bool allowZeroSigners = false}) {
+    if (_mSignatures.length == 0 && !allowZeroSigners) {
       throw Exception(
           "Transaction must be signed by at least one signer. Use transaction.sign().");
     }
@@ -261,8 +261,8 @@ class Transaction {
   }
 
   ///Returns base64-encoded TransactionEnvelope XDR object. Transaction need to have at least one signature.
-  String toEnvelopeXdrBase64() {
-    XdrTransactionEnvelope envelope = this.toEnvelopeXdr();
+  String toEnvelopeXdrBase64({bool allowZeroSigners = false}) {
+    XdrTransactionEnvelope envelope = this.toEnvelopeXdr(allowZeroSigners: allowZeroSigners);
     XdrDataOutputStream xdrOutputStream = XdrDataOutputStream();
     XdrTransactionEnvelope.encode(xdrOutputStream, envelope);
     return base64Encode(xdrOutputStream.bytes);

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -174,7 +174,7 @@ void testOrderBookRequestBuilder() {
 void testOperationFeeRequestBuilder() {
   Server server = new Server("https://horizon-testnet.stellar.org");
   Uri uri = server.operationFeeStats.buildUri();
-  assert("https://horizon-testnet.stellar.org/operation_fee_stats" ==
+  assert("https://horizon-testnet.stellar.org/fee_stats" ==
       uri.toString());
 }
 

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -217,6 +217,8 @@ void testToBase64EnvelopeXdrBuilderNoSignatures() {
         .toString()
         .contains("Transaction must be signed by at least one signer."));
   }
+
+  transaction.toEnvelopeXdrBase64(allowZeroSigners: true);
 }
 
 void testNoOperations() {


### PR DESCRIPTION
`OperationFeeStatsResponse` was failing to initialize with values. Fixed.

`OperationFeeStatsRequestBuilder` was using `/operation_fee_stats` instead of `/fee_stats`. FIxed.
https://www.stellar.org/developers/horizon/reference/endpoints/fee-stats.html